### PR TITLE
fix stuck merge

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -29,3 +29,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           cname: cardsagainstkubernetes.com
+          allow_empty_commit: true


### PR DESCRIPTION
Add allow empty commits to get gh-pages synced with recent changes despite an error in a previous pipeline